### PR TITLE
Fix problem on non-darwin systems

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,7 +24,9 @@ let currentProject = {
 	tasks: []
 };
 
-app.dock.hide();
+if (process.platform == "darwin") {
+	app.dock.hide();
+}
 
 // fix the $PATH on macOS
 fixPath();


### PR DESCRIPTION
This pull request fixes a crash when attempting to hide the (non-existent) dock on non-darwin systems.